### PR TITLE
Conversation participant

### DIFF
--- a/src/conversation/conversation.module.ts
+++ b/src/conversation/conversation.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConversationService } from './conversation.service';
 import { ConversationController } from './conversation.controller';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { Conversation } from './entities/conversation.entity';
 import { ConversationParticipant } from './entities/conversation-participation.entity';
+import { User } from '../users/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Conversation, ConversationParticipant])],
+  imports: [TypeOrmModule.forFeature([Conversation, ConversationParticipant, User])],
   controllers: [ConversationController],
   providers: [ConversationService],
   exports: [ConversationService],

--- a/src/conversation/conversation.service.ts
+++ b/src/conversation/conversation.service.ts
@@ -1,10 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { ConversationParticipant } from './entities/conversation-participation.entity';
+import { ConversationParticipant, ConversationParticipantRole } from './entities/conversation-participation.entity';
 import { Conversation } from './entities/conversation.entity';
 import { CreateConversationDto } from './dto/create-conversation.dto';
 import { UpdateConversationDto } from './dto/update-conversation.dto';
+import { AddParticipantDto } from './dto/add-participant.dto';
+import { User } from '../users/entities/user.entity';
 
 @Injectable()
 export class ConversationService {
@@ -12,7 +14,9 @@ export class ConversationService {
     @InjectRepository(Conversation)
     private readonly conversationRepository: Repository<Conversation>,
     @InjectRepository(ConversationParticipant)
-    private readonly conversationParticipantRepository: Repository<ConversationParticipant>,
+    private readonly participantRepository: Repository<ConversationParticipant>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
   ) {}
 
   async create(
@@ -42,5 +46,69 @@ export class ConversationService {
 
   async findAll(): Promise<Conversation[]> {
     return this.conversationRepository.find();
+  }
+
+  async getParticipant(
+    conversationId: string,
+    userId: string,
+  ): Promise<ConversationParticipant | null> {
+    return this.participantRepository.findOne({
+      where: {
+        conversation: { id: conversationId },
+        user: { id: userId },
+      },
+      relations: ['user', 'conversation'],
+    });
+  }
+
+  async addParticipant(
+    conversationId: string,
+    dto: AddParticipantDto,
+  ): Promise<ConversationParticipant> {
+    const conversation = await this.conversationRepository.findOne({
+      where: { id: conversationId },
+    });
+
+    if (!conversation) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    const user = await this.userRepository.findOne({
+      where: { id: dto.userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const existingParticipant = await this.getParticipant(
+      conversationId,
+      dto.userId,
+    );
+
+    if (existingParticipant) {
+      throw new BadRequestException('User is already a participant');
+    }
+
+    const participant = this.participantRepository.create({
+      conversation,
+      user,
+      role: dto.role || ConversationParticipantRole.MEMBER,
+    });
+
+    return this.participantRepository.save(participant);
+  }
+
+  async removeParticipant(
+    conversationId: string,
+    userId: string,
+  ): Promise<void> {
+    const participant = await this.getParticipant(conversationId, userId);
+
+    if (!participant) {
+      throw new NotFoundException('Participant not found');
+    }
+
+    await this.participantRepository.remove(participant);
   }
 }

--- a/src/conversation/dto/add-participant.dto.ts
+++ b/src/conversation/dto/add-participant.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID, IsEnum, IsOptional } from 'class-validator';
+import { ConversationParticipantRole } from '../entities/conversation-participation.entity';
+
+export class AddParticipantDto {
+  @ApiProperty({
+    description: 'UUID of the user to add to the conversation',
+    example: 'b3f64c9a-4c45-47f9-bc6a-217cae6d26f3',
+  })
+  @IsUUID()
+  userId: string;
+
+  @ApiProperty({
+    description: 'Role to assign to the participant',
+    enum: ConversationParticipantRole,
+    example: ConversationParticipantRole.MEMBER,
+    required: false,
+  })
+  @IsEnum(ConversationParticipantRole)
+  @IsOptional()
+  role?: ConversationParticipantRole;
+}

--- a/src/conversation/entities/conversation-participation.entity.ts
+++ b/src/conversation/entities/conversation-participation.entity.ts
@@ -1,7 +1,13 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn, Column } from 'typeorm';
 import { Conversation } from './conversation.entity';
 import { User } from 'src/users/entities/user.entity';
 import { ApiProperty } from '@nestjs/swagger';
+
+export enum ConversationParticipantRole {
+  ADMIN = 'admin',
+  MODERATOR = 'moderator',
+  MEMBER = 'member',
+}
 
 @Entity('conversation_participants')
 export class ConversationParticipant {
@@ -21,4 +27,16 @@ export class ConversationParticipant {
   @ManyToOne(() => User, (user) => user.conversations)
   @JoinColumn({ name: 'user_id' })
   user: User;
+
+  @ApiProperty({
+    description: 'Role of the participant in the conversation',
+    enum: ConversationParticipantRole,
+    example: ConversationParticipantRole.MEMBER,
+  })
+  @Column({
+    type: 'enum',
+    enum: ConversationParticipantRole,
+    default: ConversationParticipantRole.MEMBER,
+  })
+  role: ConversationParticipantRole;
 }

--- a/src/conversation/guards/conversation-permission.guard.ts
+++ b/src/conversation/guards/conversation-permission.guard.ts
@@ -1,0 +1,54 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { ConversationService } from '../conversation.service';
+import { ConversationParticipantRole } from '../entities/conversation-participation.entity';
+
+@Injectable()
+export class ConversationPermissionGuard implements CanActivate {
+  constructor(private readonly conversationService: ConversationService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId = request.user?.id;
+    const conversationId = request.params.id;
+    const targetUserId = request.params.userId || request.body.userId;
+
+    if (!userId || !conversationId) {
+      return false;
+    }
+
+    const participant = await this.conversationService.getParticipant(
+      conversationId,
+      userId,
+    );
+
+    if (!participant) {
+      return false;
+    }
+
+    // For self-removal, any participant can remove themselves
+    if (targetUserId === userId) {
+      return true;
+    }
+
+    // For other operations, check role-based permissions
+    switch (participant.role) {
+      case ConversationParticipantRole.ADMIN:
+        return true;
+      case ConversationParticipantRole.MODERATOR:
+        // Moderators can't modify admins
+        if (targetUserId) {
+          const targetParticipant = await this.conversationService.getParticipant(
+            conversationId,
+            targetUserId,
+          );
+          return (
+            !targetParticipant ||
+            targetParticipant.role !== ConversationParticipantRole.ADMIN
+          );
+        }
+        return true;
+      default:
+        return false;
+    }
+  }
+}


### PR DESCRIPTION
# Conversation Participant Management System

closes #13 

## Changes
- Added role-based participant management (admin/moderator/member)
- Created REST endpoints for adding/removing participants
- Implemented permission system with role-based access control

## Implementation Details
### New Endpoints
- `POST /conversations/:id/participants` - Add participant
- `DELETE /conversations/:id/participants/:userId` - Remove participant

### Permission System
- Admins: Full control over participants
- Moderators: Can manage non-admin participants
- Members: Can only remove themselves
- All operations require JWT authentication

### Files Changed
- `conversation-participation.entity.ts`: Added role field
- [conversation.service.ts](cci:7://file:///c:/Users/theMustang/Desktop/gg_server_prod/src/conversation/conversation.service.ts:0:0-0:0): Added participant management methods
- [conversation.controller.ts](cci:7://file:///c:/Users/theMustang/Desktop/gg_server_prod/src/conversation/conversation.controller.ts:0:0-0:0): Added REST endpoints
- `conversation-permission.guard.ts`: Added role-based access control
- [conversation.module.ts](cci:7://file:///c:/Users/theMustang/Desktop/gg_server_prod/src/conversation/conversation.module.ts:0:0-0:0): Updated dependencies

## Testing
- Endpoints accessible via Swagger UI at `/api`
- Protected by JWT authentication
- Includes input validation and error handling

## How to Test
1. Login to get JWT token
2. Add participant: `POST /conversations/:id/participants`
   ```json
   {
     "userId": "user-uuid",
     "role": "member" // or "admin"/"moderator"
   }
   ````
   Remove participant: DELETE /conversations/:id/participants/:userId